### PR TITLE
view route base_name, viewset get_queryset()

### DIFF
--- a/hacks_mbof/urls.py
+++ b/hacks_mbof/urls.py
@@ -23,7 +23,8 @@ import mbof.urls
 from mbof import views
 
 router = routers.DefaultRouter()
-router.register(r'me', views.CurrentUserViewSet)
+router.register(r'me', views.CurrentUserViewSet, base_name='me')
+router.register(r'recent_messages', views.RecentMessageViewSet, base_name='recent_messages')
 router.register(r'messages', views.MessageViewSet)
 router.register(r'users', views.UserViewSet)
 router.register(r'votes', views.VoteViewSet)

--- a/mbof/views.py
+++ b/mbof/views.py
@@ -39,19 +39,29 @@ class UserViewSet(viewsets.ModelViewSet):
 
 
 class CurrentUserViewSet(UserViewSet):
+    """
+    API endpoint that gives details about the current user.
+    """
     queryset = User.objects.filter(loginName=os.getenv('REMOTE_USER')).order_by('surname')
 
 
 class MessageViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows messages to be viewed (oldest first) or edited.
     """
     queryset = Message.objects.all().order_by('postingTime')
     serializer_class = MessageSerializer
 
+class RecentMessageViewSet(MessageViewSet):
+    """
+    API endpoint that allows messages to be viewed (newest first) or edited.
+    """
+    queryset = Message.objects.all().order_by('-postingTime')
+
+
 class VoteViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows users to be viewed or edited.
+    API endpoint that allows votes to be viewed or edited.
     """
     queryset = Vote.objects.all()
     serializer_class = VoteSerializer

--- a/mbof/views.py
+++ b/mbof/views.py
@@ -1,6 +1,6 @@
 import os
 
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.shortcuts import render, get_object_or_404
 from rest_framework import viewsets
 
@@ -42,7 +42,16 @@ class CurrentUserViewSet(UserViewSet):
     """
     API endpoint that gives details about the current user.
     """
-    queryset = User.objects.filter(loginName=os.getenv('REMOTE_USER')).order_by('surname')
+
+    def get_queryset(self):
+        """
+        Defining queryset as a method, because it's required when using dynamic expressions,
+        like the value used in `filter()`, which changes with each request.
+
+        :returns: User object which represents the current remote user
+
+        """
+        return User.objects.filter(loginName=os.getenv('REMOTE_USER'))
 
 
 class MessageViewSet(viewsets.ModelViewSet):
@@ -52,9 +61,12 @@ class MessageViewSet(viewsets.ModelViewSet):
     queryset = Message.objects.all().order_by('postingTime')
     serializer_class = MessageSerializer
 
+
 class RecentMessageViewSet(MessageViewSet):
     """
     API endpoint that allows messages to be viewed (newest first) or edited.
+
+    Notice it's a subclass of `MessageViewSet`, not `viewsets.ModelViewSet`.
     """
     queryset = Message.objects.all().order_by('-postingTime')
 


### PR DESCRIPTION
Based on discussions with @dovek:
- Some routes need `base_name` if they use the same model as others
- The dynamic query for `CurrentUserViewSet` needs to be defined in `get_queryset()`
